### PR TITLE
Fix nullable warnings and align MediatR versions

### DIFF
--- a/src/CQRSSolution.Api/CQRSSolution.Api.csproj
+++ b/src/CQRSSolution.Api/CQRSSolution.Api.csproj
@@ -10,7 +10,7 @@
     <PackageReference Include="AspNetCore.HealthChecks.AzureServiceBus" Version="9.0.0" />
     <PackageReference Include="AspNetCore.HealthChecks.UI.Client" Version="9.0.0" />
     <PackageReference Include="FluentValidation.AspNetCore" Version="11.3.1" />
-    <PackageReference Include="MediatR" Version="12.5.0" />
+    <PackageReference Include="MediatR" Version="11.1.0" />
     <PackageReference Include="MediatR.Extensions.Microsoft.DependencyInjection" Version="11.1.0" />
     <PackageReference Include="Microsoft.AspNetCore.OpenApi" Version="9.0.5" />
     <PackageReference Include="Microsoft.EntityFrameworkCore.Design" Version="9.0.5">

--- a/src/CQRSSolution.Api/Program.cs
+++ b/src/CQRSSolution.Api/Program.cs
@@ -32,7 +32,7 @@ builder.Services.AddDbContext<ApplicationDbContext>(options =>
 
 // 2. Register Application Layer services
 // MediatR - Scans the assembly where CreateOrderCommand is located (CQRSSolution.Application)
-builder.Services.AddMediatR(cfg => cfg.RegisterServicesFromAssembly(typeof(CreateOrderCommand).Assembly));
+builder.Services.AddMediatR(typeof(CreateOrderCommand).Assembly);
 
 // 3. Register Infrastructure Layer services
 // Repositories

--- a/src/CQRSSolution.Application/CQRSSolution.Application.csproj
+++ b/src/CQRSSolution.Application/CQRSSolution.Application.csproj
@@ -7,7 +7,7 @@
   <ItemGroup>
     <PackageReference Include="FluentValidation" Version="12.0.0" />
     <PackageReference Include="FluentValidation.DependencyInjectionExtensions" Version="12.0.0" />
-    <PackageReference Include="MediatR" Version="12.5.0" />
+    <PackageReference Include="MediatR" Version="11.1.0" />
     <PackageReference Include="MediatR.Extensions.Microsoft.DependencyInjection" Version="11.1.0" />
     <PackageReference Include="Microsoft.EntityFrameworkCore" Version="9.0.5" />
     <PackageReference Include="Microsoft.Extensions.Logging.Abstractions" Version="9.0.5" />

--- a/src/CQRSSolution.Application/Interfaces/IOrderRepository.cs
+++ b/src/CQRSSolution.Application/Interfaces/IOrderRepository.cs
@@ -18,21 +18,6 @@ public interface IOrderRepository : IRepository<Order>
     /// <returns>The order if found, including its items; otherwise, null.</returns>
     Task<Order?> GetByIdWithItemsAsync(Guid orderId, CancellationToken cancellationToken = default);
 
-    /// <summary>
-    /// Adds a new order to the repository.
-    /// </summary>
-    /// <param name="order">The order to add.</param>
-    /// <param name="cancellationToken">A token to cancel the operation.</param>
-    /// <returns>A task representing the asynchronous operation.</returns>
-    Task AddAsync(Order order, CancellationToken cancellationToken);
-
-    /// <summary>
-    /// Retrieves an order by its unique identifier.
-    /// </summary>
-    /// <param name="orderId">The unique identifier of the order.</param>
-    /// <param name="cancellationToken">A token to cancel the operation.</param>
-    /// <returns>A task representing the asynchronous operation. The task result contains the order if found; otherwise, null.</returns>
-    Task<Order?> GetByIdAsync(Guid orderId, CancellationToken cancellationToken);
 
     // Potentially other order-specific methods here, for example:
     // Task<IEnumerable<Order>> GetOrdersByCustomerIdAsync(Guid customerId, CancellationToken cancellationToken = default);

--- a/src/CQRSSolution.Infrastructure/AzureServiceBus/ServiceBusPublisher.cs
+++ b/src/CQRSSolution.Infrastructure/AzureServiceBus/ServiceBusPublisher.cs
@@ -12,8 +12,8 @@ namespace CQRSSolution.Infrastructure.AzureServiceBus
 {
     public class ServiceBusPublisherOptions
     {
-        public string ConnectionString { get; set; }
-        public string DefaultTopicOrQueueName { get; set; } // e.g., "ordersevents"
+        public required string ConnectionString { get; init; }
+        public required string DefaultTopicOrQueueName { get; init; } // e.g., "ordersevents"
     }
 
     public class ServiceBusPublisher : IEventBusPublisher, IAsyncDisposable

--- a/src/CQRSSolution.Infrastructure/DependencyInjection.cs
+++ b/src/CQRSSolution.Infrastructure/DependencyInjection.cs
@@ -71,7 +71,7 @@ public static class DependencyInjection
             .AddDbContextCheck<ApplicationDbContext>("database", HealthStatus.Degraded,
                 new[] { "db", "infrastructure" })
             .AddAzureServiceBusQueue(
-                configuration.GetConnectionString("ServiceBusConnection"),
+                configuration.GetConnectionString("ServiceBusConnection") ?? string.Empty,
                 configuration["QueueName"] ?? "your-queue-name", // Read from config, fallback
                 name: "azure_service_bus_queue",
                 failureStatus: HealthStatus.Degraded,

--- a/src/CQRSSolution.Infrastructure/Persistence/Repositories/OrderRepository.cs
+++ b/src/CQRSSolution.Infrastructure/Persistence/Repositories/OrderRepository.cs
@@ -31,7 +31,7 @@ public class OrderRepository : Repository<Order>, IOrderRepository
     /// </summary>
     /// <param name="order">The order to add.</param>
     /// <param name="cancellationToken">A token to cancel the operation.</param>
-    public async Task AddAsync(Order order, CancellationToken cancellationToken)
+    public override async Task AddAsync(Order order, CancellationToken cancellationToken)
     {
         await _context.Orders.AddAsync(order, cancellationToken);
         // Typically, SaveChangesAsync would be called by a Unit of Work or the command handler
@@ -44,7 +44,7 @@ public class OrderRepository : Repository<Order>, IOrderRepository
     /// <param name="orderId">The unique identifier of the order.</param>
     /// <param name="cancellationToken">A token to cancel the operation.</param>
     /// <returns>The order if found, including items; otherwise, null.</returns>
-    public async Task<Order?> GetByIdAsync(Guid orderId, CancellationToken cancellationToken)
+    public override async Task<Order?> GetByIdAsync(Guid orderId, CancellationToken cancellationToken)
     {
         return await _context.Orders
             .Include(o => o.OrderItems)


### PR DESCRIPTION
## Summary
- mark ServiceBusPublisher options as required
- ensure health check uses non-null connection string
- remove redundant methods from `IOrderRepository`
- override repo methods properly
- use MediatR 11.x across solution and adjust registration

## Testing
- `dotnet build`

------
https://chatgpt.com/codex/tasks/task_e_687c18b890f48328b12e68f8bcc03853